### PR TITLE
Fix Sub Store startup crash from Javet shrinking

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -85,13 +85,7 @@
 # ========================================
 # Javet / Native JS
 # ========================================
--keep class com.caoccao.javet.interop.V8Host { *; }
--keep class com.caoccao.javet.interop.V8Runtime { *; }
--keep class com.caoccao.javet.interop.NodeRuntime { *; }
--keep class com.caoccao.javet.interop.engine.** { *; }
--keep class com.caoccao.javet.interop.callback.** { *; }
--keep class com.caoccao.javet.interop.converters.** { *; }
--keep class com.caoccao.javet.interfaces.IJavetDirectCallable { *; }
+-keep class com.caoccao.javet.** { *; }
 -keepclassmembers class * {
     @com.caoccao.javet.annotations.V8Function <methods>;
     @com.caoccao.javet.annotations.V8Property <methods>;


### PR DESCRIPTION
Sub Store can crash on release startup even when the external Javet native library is present, because Javet Java classes referenced during native initialization may be removed or renamed by R8.

This keeps the full `com.caoccao.javet` package so JNI/native startup can resolve classes such as `NodeRuntimeOptions`. The previous foreground service manifest change was not part of the fix and is not included in this PR.