### PR TITLE
fix: Quick Settings tile cannot stop server

### DIFF
--- a/runtime/service/src/runtime/service/ProxyTileService.kt
+++ b/runtime/service/src/runtime/service/ProxyTileService.kt
@@ -28,6 +28,7 @@ import android.net.VpnService
 import android.os.Build
 import android.service.quicksettings.Tile
 import android.service.quicksettings.TileService
+import com.github.yumelira.yumebox.core.Clash
 import com.github.yumelira.yumebox.core.util.AutoStartSessionGate
 import com.github.yumelira.yumebox.core.util.PollingTimerSpecs
 import com.github.yumelira.yumebox.core.util.PollingTimers
@@ -239,10 +240,15 @@ class ProxyTileService : TileService() {
             RuntimeOwner.None -> null
         }
 
-    // Stop via the runtime-events broadcast (RuntimeForegroundController stops the session)
-    // plus stopService as belt and braces; core teardown happens in SessionRuntime.destroy.
+    // Mirrors the home-screen stop path: ask the runtime service to stop, then apply the same
+    // local core/service fallback used by LocalClashManager/ProxyRuntimeControl.
     private fun stopLocalRuntime() {
         runCatching { sendBroadcastSelf(Intent(Intents.ACTION_CLASH_REQUEST_STOP)) }
+        runCatching {
+            Clash.stopHttp()
+            Clash.stopTun()
+            Clash.reset()
+        }
         runCatching {
             applicationContext.stopService(Intent(applicationContext, TunService::class.java))
             applicationContext.stopService(Intent(applicationContext, ClashService::class.java))

--- a/runtime/service/src/runtime/service/ProxyTileService.kt
+++ b/runtime/service/src/runtime/service/ProxyTileService.kt
@@ -28,6 +28,7 @@ import android.net.VpnService
 import android.os.Build
 import android.service.quicksettings.Tile
 import android.service.quicksettings.TileService
+import com.github.yumelira.yumebox.core.util.AutoStartSessionGate
 import com.github.yumelira.yumebox.core.util.PollingTimerSpecs
 import com.github.yumelira.yumebox.core.util.PollingTimers
 import com.github.yumelira.yumebox.data.model.ProxyMode
@@ -77,7 +78,7 @@ class ProxyTileService : TileService() {
         updateJob?.cancel()
         updateJob = scope.launch {
             PollingTimers.ticks(PollingTimerSpecs.ProxyTileRefresh).collect {
-                updateTileState(currentSnapshot().running)
+                updateTileState(currentSnapshot().phase.isActiveOrStopping)
             }
         }
     }
@@ -98,19 +99,22 @@ class ProxyTileService : TileService() {
                 return@launch
             }
             val snapshot = currentSnapshot()
-            val isRunning = snapshot.running
+            val isActive = snapshot.phase.isActiveOrStopping
             val currentMode = effectiveMode(snapshot)
 
+            // If the tile visual state is stale vs the actual runtime state, sync it
+            // immediately but still perform the user's requested action — the user's tap
+            // is their intent to toggle, not just to reconcile state.
             val tileState = qsTile?.state
-            val tileStaleInactive = isRunning && tileState == Tile.STATE_INACTIVE
-            val tileStaleActive = !isRunning && tileState == Tile.STATE_ACTIVE
+            val tileStaleInactive = isActive && tileState == Tile.STATE_INACTIVE
+            val tileStaleActive = !isActive && tileState == Tile.STATE_ACTIVE
             if (tileStaleInactive || tileStaleActive) {
-                updateTileState(isRunning)
-                return@launch
+                updateTileState(isActive)
             }
 
             try {
-                if (isRunning) {
+                if (isActive) {
+                    AutoStartSessionGate.markManualPaused()
                     updateTilePendingState(isStarting = false)
                     withContext(Dispatchers.IO) {
                         if (
@@ -186,7 +190,7 @@ class ProxyTileService : TileService() {
                         initialDelayMillis = 300L,
                     )
                 )
-                updateTileState(currentSnapshot().running)
+                updateTileState(currentSnapshot().phase.isActiveOrStopping)
             }
         }
     }
@@ -240,13 +244,13 @@ class ProxyTileService : TileService() {
     private fun stopLocalRuntime() {
         runCatching { sendBroadcastSelf(Intent(Intents.ACTION_CLASH_REQUEST_STOP)) }
         runCatching {
-            stopService(Intent(this, TunService::class.java))
-            stopService(Intent(this, ClashService::class.java))
+            applicationContext.stopService(Intent(applicationContext, TunService::class.java))
+            applicationContext.stopService(Intent(applicationContext, ClashService::class.java))
         }
     }
 
     private fun effectiveMode(snapshot: RuntimeSnapshot): ProxyMode =
-        if (snapshot.running) {
+        if (snapshot.phase.isActiveOrStopping) {
             modeForOwner(snapshot.owner) ?: snapshot.targetMode
         } else {
             snapshot.targetMode

--- a/runtime/service/src/runtime/service/RuntimeForegroundController.kt
+++ b/runtime/service/src/runtime/service/RuntimeForegroundController.kt
@@ -25,6 +25,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import androidx.core.app.ServiceCompat
 import androidx.core.content.ContextCompat
 import com.github.yumelira.yumebox.core.model.LogMessage
 import com.github.yumelira.yumebox.data.model.ProxyMode
@@ -78,6 +79,7 @@ class RuntimeForegroundController(
     private var notificationJob: Job? = null
     private var runtime: SessionRuntime? = null
     private var reloadJob: Job? = null
+    private var stopRequested = false
 
     private val runtimeEventsReceiver =
         object : BroadcastReceiver() {
@@ -87,12 +89,26 @@ class RuntimeForegroundController(
                     Intents.ACTION_OVERRIDE_CHANGED -> scheduleReload()
 
                     Intents.ACTION_CLASH_REQUEST_STOP -> {
+                        if (stopRequested) return
                         reason = intent.getStringExtra(Intents.EXTRA_STOP_REASON)
+                        stopRequested = true
                         reloadJob?.cancel()
                         reloadJob = null
                         StatusProvider.markRuntimeStopping(mode)
-                        runtime?.requestStop(reason)
-                        service.stopSelf()
+                        notificationJob?.cancel()
+                        notificationJob = null
+                        thread(name = "session-runtime-stop") {
+                            val stopResult = runtime?.stop(reason)
+                            if (stopResult?.success == false) {
+                                val error = stopResult.error ?: "${label.lowercase()} runtime stop failed"
+                                this@RuntimeForegroundController.reason = error
+                                StatusProvider.markRuntimeFailed(mode)
+                                service.sendClashStopped(error)
+                                Timber.e("$label runtime stop failed: $error")
+                            }
+                            stopForegroundService()
+                            service.stopSelf()
+                        }
                     }
                 }
             }
@@ -205,12 +221,17 @@ class RuntimeForegroundController(
         reloadJob = null
         notificationJob?.cancel()
         notificationJob = null
+        stopForegroundService()
 
         runtime?.let { rt ->
-            rt.requestStop(reason)
-            // Teardown contends with an in-flight native compile on the session lock;
-            // waiting for it here would block the main thread past the ANR window.
-            thread(name = "session-runtime-destroy") { rt.destroy() }
+            if (stopRequested) {
+                rt.requestStop(reason)
+            } else {
+                rt.requestStop(reason)
+                // Teardown contends with an in-flight native compile on the session lock;
+                // waiting for it here would block the main thread past the ANR window.
+                thread(name = "session-runtime-destroy") { rt.destroy() }
+            }
         }
 
         // Guarded: the launcher may already have marked the phase Starting for the
@@ -221,6 +242,10 @@ class RuntimeForegroundController(
         service.sendClashStopped(reason)
         startupLogStore.append("$tag destroy")
         Timber.i("${service.javaClass.simpleName} destroyed: ${reason ?: "successfully"}")
+    }
+
+    private fun stopForegroundService() {
+        ServiceCompat.stopForeground(service, ServiceCompat.STOP_FOREGROUND_REMOVE)
     }
 
     fun onTrimMemory() {


### PR DESCRIPTION
Fixes Quick Settings tile stop behavior so it matches the working home-screen pause/stop path.

### What changed
- The tile now treats `Starting`, `Running`, and `Stopping` as active states, so a tap can stop a runtime even when the UI/status is mid-transition.
- The tile no longer consumes the first tap just to reconcile stale visual state; it updates the tile and still runs the requested toggle.
- The tile now calls `AutoStartSessionGate.markManualPaused()` before stopping, matching the home screen and preventing auto-start from immediately relaunching the runtime.
- The tile stop path now mirrors the home-screen local fallback: it sends the stop broadcast, directly stops the Clash HTTP/TUN core, resets core state, and stops the local services.
- `RuntimeForegroundController` now handles the stop broadcast by actively calling `SessionRuntime.stop(...)` instead of only `requestStop(...)`, so VPN/core teardown runs deterministically and the foreground notification is removed.

### Home screen parity
The home-screen start/pause path was already working and is intentionally left unchanged. This PR aligns the tile with that behavior instead of weakening the existing home-screen client fallback.

Closes #129