### PR TITLE
[codex] fix first route animations for Lab and Custom Routing

### DIFF
--- a/feature/meta/src/presentation/viewmodel/CustomRoutingViewModel.kt
+++ b/feature/meta/src/presentation/viewmodel/CustomRoutingViewModel.kt
@@ -31,6 +31,7 @@ import com.github.yumelira.yumebox.feature.meta.presentation.util.OverridePreset
 import com.github.yumelira.yumebox.feature.meta.presentation.util.analyzePresetTemplateContent
 import com.github.yumelira.yumebox.feature.meta.presentation.util.buildPresetTemplateYaml
 import com.github.yumelira.yumebox.feature.meta.presentation.util.defaultOverridePresetTemplateSelection
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -53,7 +54,7 @@ class CustomRoutingViewModel(
     val templateRoundTripSafe: StateFlow<Boolean> = templateRoundTripSafeState.asStateFlow()
 
     init {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.Default) {
             runCatching { reloadStateFromStoredContent() }
                 .onFailure {
                     Timber.e(it, "Failed to reload custom routing state from stored content")

--- a/feature/substore/src/presentation/viewmodel/FeatureViewModel.kt
+++ b/feature/substore/src/presentation/viewmodel/FeatureViewModel.kt
@@ -37,6 +37,7 @@ import com.github.yumelira.yumebox.substore.engine.NativeLibraryManager
 import com.github.yumelira.yumebox.substore.model.AutoCloseMode
 import com.github.yumelira.yumebox.substore.util.SubStoreDownloadClient
 import dev.oom_wg.purejoy.mlang.MLang
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -45,6 +46,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 class FeatureViewModel(
     store: FeatureStore,
@@ -71,6 +74,7 @@ class FeatureViewModel(
             )
 
     private var autoCloseJob: Job? = null
+    private val statusInitializationMutex = Mutex()
 
     private val _isDownloadingSubStoreFrontend = MutableStateFlow(false)
     val isDownloadingSubStoreFrontend: StateFlow<Boolean> =
@@ -155,11 +159,7 @@ class FeatureViewModel(
     }
 
     fun initializeSubStoreStatus() {
-        viewModelScope.launch {
-            _isSubStoreInitialized.value = SubStorePaths.isResourcesReady()
-            _isExtensionInstalled.value = checkExtensionInstalled()
-            initializeJavetStatus()
-        }
+        viewModelScope.launch(Dispatchers.IO) { refreshSubStoreStatus() }
     }
 
     private fun checkExtensionInstalled(): Boolean =
@@ -184,7 +184,12 @@ class FeatureViewModel(
     }
 
     fun refreshExtensionStatus() {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.IO) { refreshSubStoreStatus() }
+    }
+
+    private suspend fun refreshSubStoreStatus() {
+        statusInitializationMutex.withLock {
+            _isSubStoreInitialized.value = SubStorePaths.isResourcesReady()
             _isExtensionInstalled.value = checkExtensionInstalled()
             initializeJavetStatus()
         }


### PR DESCRIPTION
## Summary

- move Lab SubStore/native status initialization off the main dispatcher
- serialize Lab initialization and manual refresh to avoid native extraction races
- move Custom Routing's initial YAML and template analysis to the default worker dispatcher
- preserve the existing Navigation 3 slide and fade transitions unchanged

## Root cause

Lab performed filesystem checks, package lookup, and possible native/Javet extraction on the main thread during its first composition. Custom Routing similarly parsed YAML, regenerated its template, and performed round-trip comparison on the main thread during first ViewModel creation. These cold paths consumed the first navigation transition frames, while later entries appeared normal because initialization was already warm.

## Impact

The first navigation into Lab and Meta Features > Custom Routing can render the same horizontal push and subtle fade as subsequent entries, without changing page layout or animation parameters.

## Validation

- `./gradlew :feature:substore:compileDebugKotlin :app:compileDebugKotlin`
- `./gradlew :feature:substore:lintDebug`
- `./gradlew :feature:meta:compileDebugKotlin :feature:meta:testDebugUnitTest :app:compileDebugKotlin`
- `./gradlew :feature:meta:lintDebug`
- `git diff --check`

Closes #133